### PR TITLE
開始時の発声文字が検出されるよう修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -148,7 +148,8 @@ player.addListener({
     }
 
     // 500ms先に発声される文字を検出
-    const chars = player.video.findCharChange(lastTime + 500, position + 500);
+    // 初回は開始時からの差分区間、それ以降は前回実行時からの差分区間を検出
+    const chars = player.video.findCharChange(lastTime < 0 ? lastTime : lastTime + 500, position + 500);
     for (const c of chars.entered) {
       // 新しい文字が発声されようとしている
       newChar(c);


### PR DESCRIPTION
https://github.com/TextAliveJp/textalive-app-lyric-sheet/issues/4 の対応コミットになります。

IChar.startTime <= 500 となるような文字が検出できるよう Video.findCharChange() の呼び出しを変更しています。